### PR TITLE
Fix Contested journey

### DIFF
--- a/definitions/contested/json/AuthorisationCaseState.json
+++ b/definitions/contested/json/AuthorisationCaseState.json
@@ -423,13 +423,6 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyContested",
-    "CaseStateID": "awaitingPayment",
-    "UserRole": "caseworker-divorce-bulkscan",
-    "CRUD": "R"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "FinancialRemedyContested",
     "CaseStateID": "awaitingPaymentResponse",
     "UserRole": "caseworker-divorce-bulkscan",
     "CRUD": "R"


### PR DESCRIPTION
Removed 2 unnecessary attributes in AuthorisationCaseState for states that don't currently exist in the contested journey which were preventing successful uploads of the config to CCD:
- AwaitingPayment
- referredToJudge