### PR TITLE
return to Scheduling and Hearing event added

### DIFF
--- a/definitions/contested/json/CaseEvent.json
+++ b/definitions/contested/json/CaseEvent.json
@@ -345,7 +345,7 @@
     "Name": "Return to S&L",
     "Description": "Return to S&L",
     "DisplayOrder": 23,
-    "PreConditionState(s)": "caseWorkerReview",
+    "PreConditionState(s)": "caseWorkerReview;caseFileSubmitted",
     "PostConditionState": "schedulingAndHearing",
     "SecurityClassification": "Public",
     "ShowSummary": "N",


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPET-145

### Change description ###

Added 'return to Scheduling and Hearing' event, to move back from 'ready for hearing' to 'scheduling and hearing'.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
