### PR TITLE
Adding two new fields for documents

### DIFF
--- a/definitions/consented/json/AuthorisationCaseField.json
+++ b/definitions/consented/json/AuthorisationCaseField.json
@@ -4618,5 +4618,61 @@
     "CaseFieldID": "childrenInfo",
     "UserRole": "caseworker-divorce-systemupdate",
     "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "15/04/2020",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "formA",
+    "UserRole": "caseworker-divorce-financialremedy-courtadmin",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "15/04/2020",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "formA",
+    "UserRole": "caseworker-divorce-financialremedy-judiciary",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "15/04/2020",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "formA",
+    "UserRole": "caseworker-divorce-financialremedy-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "15/04/2020",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "formA",
+    "UserRole": "caseworker-divorce-systemupdate",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "15/04/2020",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "scannedD81s",
+    "UserRole": "caseworker-divorce-financialremedy-courtadmin",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "15/04/2020",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "scannedD81s",
+    "UserRole": "caseworker-divorce-financialremedy-judiciary",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "15/04/2020",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "scannedD81s",
+    "UserRole": "caseworker-divorce-financialremedy-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "15/04/2020",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "scannedD81s",
+    "UserRole": "caseworker-divorce-systemupdate",
+    "CRUD": "CRUD"
   }
 ]

--- a/definitions/consented/json/CaseField.json
+++ b/definitions/consented/json/CaseField.json
@@ -1677,7 +1677,7 @@
     "ID": "bulkScanCaseReference",
     "Label": "Exception Record Reference",
     "FieldType": "Text",
-    "SecurityClassification": "PUBLIC"
+    "SecurityClassification": "Public"
   },
   {
     "LiveFrom": "18/03/2020",
@@ -1686,6 +1686,25 @@
     "Label": "Info about children",
     "FieldType": "Collection",
     "FieldTypeParameter": "FR_ChildInfo",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "15/04/2020",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "ID": "formA",
+    "Label": "Paper Form A",
+    "HintText": "Paper Form A",
+    "FieldType": "Document",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "15/04/2020",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "ID": "scannedD81s",
+    "Label": "Scanned D81s",
+    "HintText": "Scanned D81s",
+    "FieldType": "Collection",
+    "FieldTypeParameter": "Document",
     "SecurityClassification": "Public"
   }
 ]

--- a/definitions/consented/json/CaseTypeTab.json
+++ b/definitions/consented/json/CaseTypeTab.json
@@ -1244,6 +1244,26 @@
     "TabFieldDisplayOrder": 21
   },
   {
+    "LiveFrom": "15/04/2020",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "Channel": "CaseWorker",
+    "TabID": "CaseDetails",
+    "TabLabel": "Case Documents",
+    "TabDisplayOrder": 7,
+    "CaseFieldID": "formA",
+    "TabFieldDisplayOrder": 22
+  },
+  {
+    "LiveFrom": "15/04/2020",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "Channel": "CaseWorker",
+    "TabID": "CaseDetails",
+    "TabLabel": "Case Documents",
+    "TabDisplayOrder": 7,
+    "CaseFieldID": "scannedD81s",
+    "TabFieldDisplayOrder": 23
+  },
+  {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyMVP2",
     "Channel": "CaseWorker",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BSP-391

### Change description ###

Added two new CCD consented fields, `formA` and `scannedD81s`.

Field type is `Document` and a collection of `Document`s but FR has got a complex type `ScannedDocument` with metadata if that is needed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
