### PR TITLE
BSP-287 & BSP-289: Add callbacks for 'assign to judge' event and new prestate for FR_HWFDecisionMade

### DIFF
--- a/definitions/consented/json/CaseEvent.json
+++ b/definitions/consented/json/CaseEvent.json
@@ -452,6 +452,8 @@
     "DisplayOrder": 20,
     "PreConditionState(s)": "consentOrderApproved",
     "PostConditionState": "referredToJudge",
+    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/case-orchestration/notify/assign-to-judge",
+    "RetriesTimeoutURLSubmittedEvent": "3,4,5",
     "SecurityClassification": "Public",
     "ShowEventNotes": "Y"
   },

--- a/definitions/consented/json/CaseEvent.json
+++ b/definitions/consented/json/CaseEvent.json
@@ -440,6 +440,8 @@
     "DisplayOrder": 19,
     "PreConditionState(s)": "orderMade",
     "PostConditionState": "referredToJudge",
+    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/case-orchestration/notify/assign-to-judge",
+    "RetriesTimeoutURLSubmittedEvent": "3,4,5",
     "SecurityClassification": "Public",
     "ShowEventNotes": "Y"
   },
@@ -466,6 +468,8 @@
     "DisplayOrder": 21,
     "PreConditionState(s)": "consentOrderMade",
     "PostConditionState": "referredToJudge",
+    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/case-orchestration/notify/assign-to-judge",
+    "RetriesTimeoutURLSubmittedEvent": "3,4,5",
     "SecurityClassification": "Public",
     "ShowEventNotes": "Y"
   },
@@ -506,6 +510,8 @@
     "DisplayOrder": 24,
     "PreConditionState(s)": "close",
     "PostConditionState": "referredToJudge",
+    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/case-orchestration/notify/assign-to-judge",
+    "RetriesTimeoutURLSubmittedEvent": "3,4,5",
     "SecurityClassification": "Public",
     "ShowEventNotes": "Y"
   },

--- a/definitions/consented/json/CaseEvent.json
+++ b/definitions/consented/json/CaseEvent.json
@@ -256,7 +256,7 @@
     "Name": "HWF Application Accepted",
     "Description": "HWF Application Accepted",
     "DisplayOrder": 6,
-    "PreConditionState(s)": "awaitingHWFDecision",
+    "PreConditionState(s)": "awaitingHWFDecision;newPaperCase",
     "PostConditionState": "applicationSubmitted",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/case-orchestration/remove-case-data-state",
     "RetriesTimeoutURLAboutToSubmitEvent": "3,4,5",


### PR DESCRIPTION
Added callback URLs to all 'assign to judge' events to trigger BE logic for BSP-287:
https://tools.hmcts.net/jira/browse/BSP-287

Added 'newPaperCase' to prestate of 'FR_HWFDecisionMade' event for BSP-289:
https://tools.hmcts.net/jira/browse/BSP-289