### PR TITLE
FR-1725 - adding hide for child gender if its not set

### DIFF
--- a/definitions/consented/json/CaseEventToFields/CaseEventToFields.json
+++ b/definitions/consented/json/CaseEventToFields/CaseEventToFields.json
@@ -917,7 +917,7 @@
     "PageID": 6,
     "PageDisplayOrder": 6,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment  Order\"",
+    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment Order\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -930,7 +930,7 @@
     "PageID": 6,
     "PageDisplayOrder": 6,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment  Order\"",
+    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment Order\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -2067,7 +2067,7 @@
     "PageID": 6,
     "PageDisplayOrder": 6,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment  Order\"",
+    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment Order\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -2080,7 +2080,7 @@
     "PageID": 6,
     "PageDisplayOrder": 6,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment  Order\"",
+    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment Order\"",
     "ShowSummaryChangeOption": "Y"
   },
   {

--- a/definitions/consented/json/ComplexTypes.json
+++ b/definitions/consented/json/ComplexTypes.json
@@ -665,6 +665,7 @@
     "FieldType": "FixedList",
     "FieldTypeParameter": "FR_Gender",
     "ElementLabel": "Gender",
+    "FieldShowCondition": "gender=\"Male\" OR gender=\"Female\" OR gender=\"male\" OR gender=\"female\" ",
     "SecurityClassification": "Public"
   },
   {

--- a/definitions/consented/json/FixedLists/FixedLists.json
+++ b/definitions/consented/json/FixedLists/FixedLists.json
@@ -272,7 +272,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "FR_ms_natureApplication",
-    "ListElementCode": "Property Adjustment  Order",
+    "ListElementCode": "Property Adjustment Order",
     "ListElement": "Property Adjustment Order"
   },
   {
@@ -1820,13 +1820,13 @@
   {
     "LiveFrom": "18/03/2020",
     "ID": "FR_Gender",
-    "ListElementCode": "male",
+    "ListElementCode": "Male",
     "ListElement": "Male"
   },
   {
     "LiveFrom": "18/03/2020",
     "ID": "FR_Gender",
-    "ListElementCode": "female",
+    "ListElementCode": "Female",
     "ListElement": "Female"
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FR-1725

### Change description ###

Hiding the child gender field (populated through BSP if the value is 'not given' aka - not Male or Female

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
