### PR TITLE
Remove extra space from 'Property Adjustment Order'

### DIFF
--- a/definitions/consented/json/CaseEventToFields/CaseEventToFields.json
+++ b/definitions/consented/json/CaseEventToFields/CaseEventToFields.json
@@ -917,7 +917,7 @@
     "PageID": 6,
     "PageDisplayOrder": 6,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment  Order\"",
+    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment Order\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -930,7 +930,7 @@
     "PageID": 6,
     "PageDisplayOrder": 6,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment  Order\"",
+    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment Order\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -2067,7 +2067,7 @@
     "PageID": 6,
     "PageDisplayOrder": 6,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment  Order\"",
+    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment Order\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -2080,7 +2080,7 @@
     "PageID": 6,
     "PageDisplayOrder": 6,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment  Order\"",
+    "FieldShowCondition": "natureOfApplication2 CONTAINS \"Property Adjustment Order\"",
     "ShowSummaryChangeOption": "Y"
   },
   {

--- a/definitions/consented/json/FixedLists/FixedLists.json
+++ b/definitions/consented/json/FixedLists/FixedLists.json
@@ -272,7 +272,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "FR_ms_natureApplication",
-    "ListElementCode": "Property Adjustment  Order",
+    "ListElementCode": "Property Adjustment Order",
     "ListElement": "Property Adjustment Order"
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FR-1696


### Change description ###
Remove extra space from 'Property Adjustment Order' in prep for database change

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
