### PR TITLE
Added Awaiting Judiciary Response (consent) state and event

### DIFF
--- a/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -1076,5 +1076,12 @@
     "CaseEventID": "FR_generalOrderCourtAdmin",
     "UserRole": "caseworker-divorce-financialremedy-courtadmin",
     "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FinancialRemedyContested",
+    "CaseEventID": "FR_assignToJudgeConsent",
+    "UserRole": "caseworker-divorce-financialremedy-courtadmin",
+    "CRUD": "CRUD"
   }
 ]

--- a/definitions/contested/json/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/definitions/contested/json/AuthorisationCaseState/AuthorisationCaseState.json
@@ -170,6 +170,13 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyContested",
+    "CaseStateID": "awaitingJudiciaryResponseConsent",
+    "UserRole": "caseworker-divorce-financialremedy-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FinancialRemedyContested",
     "CaseStateID": "caseAdded",
     "UserRole": "caseworker-divorce-financialremedy-courtadmin",
     "CRUD": "CRUD"
@@ -338,6 +345,13 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyContested",
+    "CaseStateID": "awaitingJudiciaryResponseConsent",
+    "UserRole": "caseworker-divorce-financialremedy-courtadmin",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FinancialRemedyContested",
     "CaseStateID": "caseAdded",
     "UserRole": "caseworker-divorce-financialremedy-judiciary",
     "CRUD": "CRUD"
@@ -500,6 +514,13 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseStateID": "consentedOrderSubmitted",
+    "UserRole": "caseworker-divorce-financialremedy-judiciary",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FinancialRemedyContested",
+    "CaseStateID": "awaitingJudiciaryResponseConsent",
     "UserRole": "caseworker-divorce-financialremedy-judiciary",
     "CRUD": "R"
   },
@@ -675,6 +696,13 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyContested",
+    "CaseStateID": "awaitingJudiciaryResponseConsent",
+    "UserRole": "caseworker-divorce-bulkscan",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FinancialRemedyContested",
     "CaseStateID": "caseAdded",
     "UserRole": "caseworker-divorce-systemupdate",
     "CRUD": "CRUD"
@@ -837,6 +865,13 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseStateID": "consentedOrderSubmitted",
+    "UserRole": "caseworker-divorce-systemupdate",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FinancialRemedyContested",
+    "CaseStateID": "awaitingJudiciaryResponseConsent",
     "UserRole": "caseworker-divorce-systemupdate",
     "CRUD": "R"
   }

--- a/definitions/contested/json/CaseEvent/CaseEvent.json
+++ b/definitions/contested/json/CaseEvent/CaseEvent.json
@@ -776,7 +776,7 @@
     "PreConditionState(s)": "consentedOrderSubmitted",
     "PostConditionState": "awaitingJudiciaryResponseConsent",
     "SecurityClassification": "Public",
-    "ShowEventNotes": "N",
+    "ShowEventNotes": "Y",
     "ShowSummary": "Y"
   }
 ]

--- a/definitions/contested/json/CaseEvent/CaseEvent.json
+++ b/definitions/contested/json/CaseEvent/CaseEvent.json
@@ -765,5 +765,18 @@
     "SecurityClassification": "Public",
     "ShowEventNotes": "N",
     "ShowSummary": "Y"
+  },
+  {
+    "LiveFrom": "13/12/2019",
+    "CaseTypeID": "FinancialRemedyContested",
+    "ID": "FR_assignToJudgeConsent",
+    "Name": "Assign to Judge (consent)",
+    "Description": "Assign to Judge (consent)",
+    "DisplayOrder": 116,
+    "PreConditionState(s)": "consentedOrderSubmitted",
+    "PostConditionState": "awaitingJudiciaryResponseConsent",
+    "SecurityClassification": "Public",
+    "ShowEventNotes": "N",
+    "ShowSummary": "Y"
   }
 ]

--- a/definitions/contested/json/CaseTypeTab/CaseTypeTab-nonprod.json
+++ b/definitions/contested/json/CaseTypeTab/CaseTypeTab-nonprod.json
@@ -8,4 +8,5 @@
     "CaseFieldID": "generalLetterCollection",
     "TabFieldDisplayOrder": 17
   }
+
 ]

--- a/definitions/contested/json/State/State.json
+++ b/definitions/contested/json/State/State.json
@@ -190,5 +190,13 @@
     "Name": "Consented Order Submitted",
     "DisplayOrder": 24,
     "TitleDisplay": "**${[CASE_REFERENCE]}  ${applicantLName}  vs ${respondentLName}**"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FinancialRemedyContested",
+    "ID": "awaitingJudiciaryResponseConsent",
+    "Name": "Awaiting Judiciary Response (Consent)",
+    "DisplayOrder": 25,
+    "TitleDisplay": "**${[CASE_REFERENCE]}  ${applicantLName}  vs ${respondentLName}**"
   }
 ]


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/FR-1746

Created new "Assign to Judge (consent)" event that moves case from 'consentedOrderSubmitted' state to new 'awaitingJudiciaryResponseConsent' state.

This can only be triggered by the court admins.

No need to explicitly toggle this change as the event can only be called from prestate 'consentedOrderSubmitted' which is toggled off already - therefore unable to get into required prestate on Production