### PR TITLE
RPET-376: Add back nottinghamCourtListGA field

### DIFF
--- a/definitions/contested/json/CaseField/CaseField.json
+++ b/definitions/contested/json/CaseField/CaseField.json
@@ -1307,6 +1307,15 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyContested",
+    "ID": "nottinghamCourtListGA",
+    "Label": "Choose hearing location",
+    "FieldType": "FixedList",
+    "FieldTypeParameter": "FR_s_NottinghamList",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FinancialRemedyContested",
     "ID": "judgeAllocatedLabel",
     "Label": "## The application is suitable to be heard by a:",
     "FieldType": "Label",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPET-376

### Change description ###

+ Unblocks 114 cases from moving forward due to having this value on the case data but not in config.
+ Case migration to fix this properly will be done at a later date.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
