### PR TITLE
RPET-164 fix CVE 1589 Prototype Pollution on ini package

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "bl": "4.0.3",
     "eslint-utils": "^1.4.1",
     "https-proxy-agent": "2.2.3",
-    "lodash": "4.17.19"
+    "lodash": "4.17.19",
+    "ini":  "1.3.6"
   }
 }


### PR DESCRIPTION
fixes CVE issue that breaks build pipeline

┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ ini                                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >1.3.6                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ codeceptjs                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ codeceptjs > requireg > rc > ini                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1589     



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
