### PR TITLE
FR-349 APPSOL & RESPSOL permissions update

### DIFF
--- a/definitions/consented/json/AuthorisationCaseField/AuthorisationCaseField-respSol-nonprod.json
+++ b/definitions/consented/json/AuthorisationCaseField/AuthorisationCaseField-respSol-nonprod.json
@@ -536,27 +536,27 @@
     "CaseTypeID": "FinancialRemedyMVP2",
     "CaseFieldID": "bulkPrintCoverSheetApp",
     "UserRole": "[APPSOLICITOR]",
-    "CRUD": "CRU"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyMVP2",
     "CaseFieldID": "bulkPrintCoverSheetResp",
     "UserRole": "[RESPSOLICITOR]",
-    "CRUD": "CRU"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyMVP2",
     "CaseFieldID": "bulkPrintCoverSheetAppConfidential",
     "UserRole": "[APPSOLICITOR]",
-    "CRUD": "CRU"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyMVP2",
     "CaseFieldID": "bulkPrintCoverSheetRespConfidential",
     "UserRole": "[RESPSOLICITOR]",
-    "CRUD": "CRU"
+    "CRUD": "R"
   }
 ]

--- a/definitions/consented/json/AuthorisationCaseField/AuthorisationCaseField-respSol-nonprod.json
+++ b/definitions/consented/json/AuthorisationCaseField/AuthorisationCaseField-respSol-nonprod.json
@@ -530,5 +530,33 @@
     "CaseFieldID": "RespondentOrganisationPolicy",
     "UserRole": "caseworker-divorce-financialremedy-solicitor",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "bulkPrintCoverSheetApp",
+    "UserRole": "[APPSOLICITOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "bulkPrintCoverSheetResp",
+    "UserRole": "[RESPSOLICITOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "bulkPrintCoverSheetAppConfidential",
+    "UserRole": "[APPSOLICITOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "bulkPrintCoverSheetRespConfidential",
+    "UserRole": "[RESPSOLICITOR]",
+    "CRUD": "CRU"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FR-349

### Change description ###
Adding remaining permissions for APPSOL and RESPSOL to view coversheets, as they were missing


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
