### PR TITLE
RPET-582- Updating Logic for complexity field to correct value

### DIFF
--- a/definitions/contested/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/contested/json/CaseTypeTab/CaseTypeTab.json
@@ -1289,7 +1289,7 @@
     "TabDisplayOrder": 11,
     "CaseFieldID": "tabStandardList",
     "TabFieldDisplayOrder": 16,
-    "FieldShowCondition": "addToComplexityListOfCourts=\"trueNo\""
+    "FieldShowCondition": "addToComplexityListOfCourts=\"falseNo\""
   },
   {
     "LiveFrom": "01/01/2017",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RPET-582


### Change description ###
When users selected "No" from the `addToComplexityListOfCourts` Options
The field show condition was incorrect for this field, it has now been updated to point to the correct value that is stored by the fixed list: 

```  
    "LiveFrom": "01/01/2017",
    "ID": "FR_complexityList",
    "ListElementCode": "falseNo",
    "ListElement": "No"
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
