### PR TITLE
Updating Contested references to cleveland

### DIFF
--- a/definitions/contested/json/CaseEventToFields/CaseEventToFields-newPaperCase.json
+++ b/definitions/contested/json/CaseEventToFields/CaseEventToFields-newPaperCase.json
@@ -996,7 +996,7 @@
     "PageID": 10,
     "PageDisplayOrder": 10,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleaveland\"",
+    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleveland\"",
     "ShowSummaryChangeOption": "Y"
   },
   {

--- a/definitions/contested/json/CaseEventToFields/CaseEventToFields.json
+++ b/definitions/contested/json/CaseEventToFields/CaseEventToFields.json
@@ -1284,7 +1284,7 @@
     "PageID": 13,
     "PageDisplayOrder": 13,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleaveland\"",
+    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleveland\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -2489,7 +2489,7 @@
     "PageID": 1,
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleaveland\"",
+    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleveland\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -2863,7 +2863,7 @@
     "PageID": 1,
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleaveland\"",
+    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleveland\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -4844,7 +4844,7 @@
     "PageID": 13,
     "PageDisplayOrder": 13,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleaveland\"",
+    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleveland\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -7638,7 +7638,7 @@
     "PageID": 1,
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "generalApplicationDirectionsHearingRequired=\"Yes\" AND generalApplicationDirections_regionList=\"northeast\" AND generalApplicationDirections_northWestFRCList=\"cleaveland\"",
+    "FieldShowCondition": "generalApplicationDirectionsHearingRequired=\"Yes\" AND generalApplicationDirections_regionList=\"northeast\" AND generalApplicationDirections_northEastFRCList=\"cleveland\"",
     "ShowSummaryChangeOption": "Y"
   },
   {

--- a/definitions/contested/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/contested/json/CaseTypeTab/CaseTypeTab.json
@@ -1525,7 +1525,7 @@
     "TabDisplayOrder": 11,
     "CaseFieldID": "cleavelandCourtList",
     "TabFieldDisplayOrder": 39,
-    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleaveland\""
+    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleveland\""
   },
   {
     "LiveFrom": "01/01/2017",
@@ -2189,7 +2189,7 @@
     "TabDisplayOrder": 15,
     "CaseFieldID": "cleavelandCourtList",
     "TabFieldDisplayOrder": 27,
-    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleaveland\""
+    "FieldShowCondition": "regionList=\"northeast\" AND northEastFRCList=\"cleveland\""
   },
   {
     "LiveFrom": "01/01/2017",


### PR DESCRIPTION
### Change description ###
- Updating Contested references to cleveland - as 'cleaveland' does not exist in the NorthEastFRCList

```    
    "CaseTypeID": "FinancialRemedyContested",
    ...
    "ID": "northEastFRCList",
    "FieldType": "FixedList",
    "FieldTypeParameter": "FR_ne_frc_list",
```

```
    "CaseTypeID": "FinancialRemedyContested",
    ...
    "ID": "generalApplicationDirections_northEastFRCList",
    "FieldType": "FixedList",
    "FieldTypeParameter": "FR_ne_frc_list",
```
**FR_ne_frc_list Fixed List:**

```  
{
    "LiveFrom": "01/01/2017",
    "ID": "FR_ne_frc_list",
    "ListElementCode": "cleaveland",
    "ListElement": "Cleveland Durham and Northumbria FRC "
 },
```
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
