### PR TITLE
Updating to NorthEast, as this FRC is NE not NW

### DIFF
--- a/definitions/contested/json/CaseEventToFields/CaseEventToFields.json
+++ b/definitions/contested/json/CaseEventToFields/CaseEventToFields.json
@@ -7638,7 +7638,7 @@
     "PageID": 1,
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
-    "FieldShowCondition": "generalApplicationDirectionsHearingRequired=\"Yes\" AND generalApplicationDirections_regionList=\"northeast\" AND generalApplicationDirections_northWestFRCList=\"cleaveland\"",
+    "FieldShowCondition": "generalApplicationDirectionsHearingRequired=\"Yes\" AND generalApplicationDirections_regionList=\"northeast\" AND generalApplicationDirections_northEastFRCList=\"cleaveland\"",
     "ShowSummaryChangeOption": "Y"
   },
   {


### PR DESCRIPTION
### Change description ###
Logic does not make sense, regionList "northEast" & NorthWest = "cleaveland"

Cleaveland is under a NorthEast court, logic updated to reflect this


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
