### PR TITLE
RPET-946: Remove RespSolOrg field on Contested Paper Case Creation

### DIFF
--- a/definitions/contested/json/CaseEventToFields/CaseEventToFields.json
+++ b/definitions/contested/json/CaseEventToFields/CaseEventToFields.json
@@ -7914,19 +7914,6 @@
     "ShowSummaryChangeOption": "Y"
   },
   {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "FinancialRemedyContested",
-    "CaseEventID": "FR_newPaperCase",
-    "CaseFieldID": "RespondentOrganisationPolicy",
-    "PageFieldDisplayOrder": 3,
-    "DisplayContext": "OPTIONAL",
-    "PageID": 5,
-    "PageDisplayOrder": 5,
-    "PageColumnNumber": 1,
-    "FieldShowCondition": "respondentRepresented=\"Yes\"",
-    "ShowSummaryChangeOption": "Y"
-  },
-  {
     "LiveFrom": "01/10/2020",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_amendApplication",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RPET-946


### Change description ###
- Remove RespSolOrg field on Contested Paper Case Creation
- Leaving the case field in the config so we dont break existing cases that contain this field


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
