### PR TITLE
Bump ccd chart version to 5.0.4

### DIFF
--- a/charts/finrem-ccd-definitions/Chart.yaml
+++ b/charts/finrem-ccd-definitions/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     version: ~2.3.4
     repository: '@hmctspublic'
   - name: ccd
-    version: 5.0.2
+    version: 5.0.4
     repository: '@hmctspublic'
     tags:
       - ccd-pr

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "ccdUrl": "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
     },
     "preview": {
-      "cosUrl": "http://finrem-cos-pr-567.service.core-compute-preview.internal",
+      "cosUrl": "http://finrem-cos-pr-583.service.core-compute-preview.internal",
       "ccdUrl": "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
     },
     "ithc": {


### PR DESCRIPTION
- Bump ccd chart version to 5.0.4