### PR TITLE
RPET-1016: Hide Case History view from Respondent Solicitor

### DIFF
--- a/definitions/consented/json/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/definitions/consented/json/AuthorisationCaseField/AuthorisationCaseField.json
@@ -1785,6 +1785,13 @@
     "CRUD": "R"
   },
   {
+    "LiveFrom": "27/05/2021",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "LabelState",
+    "UserRole": "[RESPSOLICITOR]",
+    "CRUD": "CRU"
+  },
+  {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyMVP2",
     "CaseFieldID": "approvedConsentOrderLetter",

--- a/definitions/consented/json/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/definitions/consented/json/AuthorisationCaseField/AuthorisationCaseField.json
@@ -1785,6 +1785,13 @@
     "CRUD": "R"
   },
   {
+    "LiveFrom": "27/05/2017",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "CaseHistoryViewer",
+    "UserRole": "[CREATOR]",
+    "CRUD": "R"
+  },
+  {
     "LiveFrom": "27/05/2021",
     "CaseTypeID": "FinancialRemedyMVP2",
     "CaseFieldID": "LabelState",

--- a/definitions/consented/json/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/definitions/consented/json/AuthorisationCaseField/AuthorisationCaseField.json
@@ -1781,7 +1781,7 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyMVP2",
     "CaseFieldID": "CaseHistoryViewer",
-    "UserRole": "caseworker-divorce-financialremedy-solicitor",
+    "UserRole": "[APPSOLICITOR]",
     "CRUD": "R"
   },
   {

--- a/definitions/consented/json/CaseField/CaseField.json
+++ b/definitions/consented/json/CaseField/CaseField.json
@@ -1891,5 +1891,13 @@
     "FieldType": "Collection",
     "FieldTypeParameter": "FR_TransferCourtEmail",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "27/05/2021",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "ID": "LabelState",
+    "Label": "#### Case State: ${[STATE]}",
+    "FieldType": "Label",
+    "SecurityClassification": "Public"
   }
 ]

--- a/definitions/consented/json/CaseRoles.json
+++ b/definitions/consented/json/CaseRoles.json
@@ -12,5 +12,12 @@
     "ID": "[APPSOLICITOR]",
     "Name": "Applicant's Solicitor",
     "Description": "Role to isolate events available for Applicant's Solicitor"
+  },
+  {
+    "LiveFrom": "27/05/2021",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "ID": "[CREATOR]",
+    "Name": "Creator of case",
+    "Description": "Role specified by CCD"
   }
 ]

--- a/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
@@ -17,7 +17,7 @@
     "TabID": "State",
     "TabLabel": "State",
     "TabDisplayOrder": 1,
-    "CaseFieldID": "[STATE]",
+    "CaseFieldID": "LabelState",
     "UserRole": "[RESPSOLICITOR]",
     "TabFieldDisplayOrder": 1
   },

--- a/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
@@ -7,7 +7,6 @@
     "TabLabel": "History",
     "TabDisplayOrder": 1,
     "CaseFieldID": "CaseHistoryViewer",
-    "UserRole": "[APPSOLICITOR]",
     "TabFieldDisplayOrder": 1
   },
   {

--- a/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
@@ -10,6 +10,16 @@
     "TabFieldDisplayOrder": 1
   },
   {
+    "LiveFrom": "26/05/2021",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "Channel": "CaseWorker",
+    "TabID": "state",
+    "TabLabel": "State",
+    "TabDisplayOrder": 1,
+    "CaseFieldID": "[STATE]",
+    "TabFieldDisplayOrder": 1
+  },
+  {
     "LiveFrom": "16/03/2020",
     "CaseTypeID": "FinancialRemedyMVP2",
     "Channel": "CaseWorker",

--- a/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
@@ -13,7 +13,7 @@
     "LiveFrom": "26/05/2021",
     "CaseTypeID": "FinancialRemedyMVP2",
     "Channel": "CaseWorker",
-    "TabID": "State",
+    "TabID": "state",
     "TabLabel": "State",
     "TabDisplayOrder": 1,
     "CaseFieldID": "LabelState",

--- a/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
@@ -7,6 +7,7 @@
     "TabLabel": "History",
     "TabDisplayOrder": 1,
     "CaseFieldID": "CaseHistoryViewer",
+    "UserRole": "[APPSOLICITOR]",
     "TabFieldDisplayOrder": 1
   },
   {
@@ -17,6 +18,7 @@
     "TabLabel": "State",
     "TabDisplayOrder": 1,
     "CaseFieldID": "[STATE]",
+    "UserRole": "[RESPSOLICITOR]",
     "TabFieldDisplayOrder": 1
   },
   {

--- a/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
@@ -1,16 +1,5 @@
 [
   {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "FinancialRemedyMVP2",
-    "Channel": "CaseWorker",
-    "TabID": "CaseHistoryViewer",
-    "TabLabel": "History",
-    "TabDisplayOrder": 1,
-    "CaseFieldID": "CaseHistoryViewer",
-    "UserRole": "[APPSOLICITOR]",
-    "TabFieldDisplayOrder": 1
-  },
-  {
     "LiveFrom": "26/05/2021",
     "CaseTypeID": "FinancialRemedyMVP2",
     "Channel": "CaseWorker",
@@ -19,6 +8,17 @@
     "TabDisplayOrder": 1,
     "CaseFieldID": "[STATE]",
     "UserRole": "[RESPSOLICITOR]",
+    "TabFieldDisplayOrder": 1
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "Channel": "CaseWorker",
+    "TabID": "CaseHistoryViewer",
+    "TabLabel": "History",
+    "TabDisplayOrder": 1,
+    "CaseFieldID": "CaseHistoryViewer",
+    "UserRole": "[APPSOLICITOR]",
     "TabFieldDisplayOrder": 1
   },
   {

--- a/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/consented/json/CaseTypeTab/CaseTypeTab.json
@@ -1,16 +1,5 @@
 [
   {
-    "LiveFrom": "26/05/2021",
-    "CaseTypeID": "FinancialRemedyMVP2",
-    "Channel": "CaseWorker",
-    "TabID": "state",
-    "TabLabel": "State",
-    "TabDisplayOrder": 1,
-    "CaseFieldID": "[STATE]",
-    "UserRole": "[RESPSOLICITOR]",
-    "TabFieldDisplayOrder": 1
-  },
-  {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyMVP2",
     "Channel": "CaseWorker",
@@ -19,6 +8,17 @@
     "TabDisplayOrder": 1,
     "CaseFieldID": "CaseHistoryViewer",
     "UserRole": "[APPSOLICITOR]",
+    "TabFieldDisplayOrder": 1
+  },
+  {
+    "LiveFrom": "26/05/2021",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "Channel": "CaseWorker",
+    "TabID": "State",
+    "TabLabel": "State",
+    "TabDisplayOrder": 1,
+    "CaseFieldID": "[STATE]",
+    "UserRole": "[RESPSOLICITOR]",
     "TabFieldDisplayOrder": 1
   },
   {

--- a/definitions/contested/json/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/definitions/contested/json/AuthorisationCaseField/AuthorisationCaseField.json
@@ -1081,8 +1081,15 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseFieldID": "CaseHistoryViewer",
-    "UserRole": "caseworker-divorce-financialremedy-solicitor",
+    "UserRole": "[APPSOLICITOR]",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "27/05/2021",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseFieldID": "LabelState",
+    "UserRole": "[RESPSOLICITOR]",
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/contested/json/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/definitions/contested/json/AuthorisationCaseField/AuthorisationCaseField.json
@@ -1085,6 +1085,13 @@
     "CRUD": "R"
   },
   {
+    "LiveFrom": "27/05/2017",
+    "CaseTypeID": "FinancialRemedyContested",
+    "CaseFieldID": "CaseHistoryViewer",
+    "UserRole": "[CREATOR]",
+    "CRUD": "R"
+  },
+  {
     "LiveFrom": "27/05/2021",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseFieldID": "LabelState",

--- a/definitions/contested/json/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/definitions/contested/json/AuthorisationCaseField/AuthorisationCaseField.json
@@ -1086,7 +1086,7 @@
   },
   {
     "LiveFrom": "27/05/2021",
-    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseTypeID": "FinancialRemedyContested",
     "CaseFieldID": "LabelState",
     "UserRole": "[RESPSOLICITOR]",
     "CRUD": "CRU"

--- a/definitions/contested/json/CaseField/CaseField.json
+++ b/definitions/contested/json/CaseField/CaseField.json
@@ -3954,5 +3954,13 @@
     "FieldType": "Collection",
     "FieldTypeParameter": "FR_uploadCaseDocument",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "27/05/2021",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "ID": "LabelState",
+    "Label": "#### Case State: ${[STATE]}",
+    "FieldType": "Label",
+    "SecurityClassification": "Public"
   }
 ]

--- a/definitions/contested/json/CaseField/CaseField.json
+++ b/definitions/contested/json/CaseField/CaseField.json
@@ -3957,7 +3957,7 @@
   },
   {
     "LiveFrom": "27/05/2021",
-    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseTypeID": "FinancialRemedyContested",
     "ID": "LabelState",
     "Label": "#### Case State: ${[STATE]}",
     "FieldType": "Label",

--- a/definitions/contested/json/CaseRoles/CaseRoles.json
+++ b/definitions/contested/json/CaseRoles/CaseRoles.json
@@ -16,5 +16,14 @@
     "Description": "Role to isolate events available for Applicant's Solicitor",
     "JurisdictionID": "DIVORCE",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "27/05/2021",
+    "CaseTypeID": "FinancialRemedyContested",
+    "ID": "[CREATOR]",
+    "Name": "Creator of case",
+    "Description": "Role specified by CCD",
+    "JurisdictionID": "DIVORCE",
+    "SecurityClassification": "Public"
   }
 ]

--- a/definitions/contested/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/contested/json/CaseTypeTab/CaseTypeTab.json
@@ -12,7 +12,7 @@
     "LiveFrom": "26/05/2021",
     "CaseTypeID": "FinancialRemedyContested",
     "Channel": "CaseWorker",
-    "TabID": "State",
+    "TabID": "state",
     "TabLabel": "State",
     "TabDisplayOrder": 1,
     "CaseFieldID": "LabelState",

--- a/definitions/contested/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/contested/json/CaseTypeTab/CaseTypeTab.json
@@ -9,6 +9,17 @@
     "TabFieldDisplayOrder": 1
   },
   {
+    "LiveFrom": "26/05/2021",
+    "CaseTypeID": "FinancialRemedyMVP2",
+    "Channel": "CaseWorker",
+    "TabID": "State",
+    "TabLabel": "State",
+    "TabDisplayOrder": 1,
+    "CaseFieldID": "LabelState",
+    "UserRole": "[RESPSOLICITOR]",
+    "TabFieldDisplayOrder": 1
+  },
+  {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyContested",
     "TabID": "applicantDetailsTab",

--- a/definitions/contested/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/contested/json/CaseTypeTab/CaseTypeTab.json
@@ -10,7 +10,7 @@
   },
   {
     "LiveFrom": "26/05/2021",
-    "CaseTypeID": "FinancialRemedyMVP2",
+    "CaseTypeID": "FinancialRemedyContested",
     "Channel": "CaseWorker",
     "TabID": "State",
     "TabLabel": "State",

--- a/test/unit/definitions/consented/CaseTypeTab.test.js
+++ b/test/unit/definitions/consented/CaseTypeTab.test.js
@@ -60,7 +60,7 @@ describe('CaseTypeTab', () => {
   });
 
   const expected = {
-    State: 1,
+    state: 1,
     CaseHistoryViewer: 1,
     applicantDetails: 2,
     respondentDetails: 3,
@@ -90,7 +90,7 @@ describe('CaseTypeTab', () => {
   it('should contain a valid Tab IDs', () => {
     expect(tabIds).to.eql([
       'CaseHistoryViewer',
-      'State',
+      'state',
       'applicantDetails',
       'respondentDetails',
       'divorceDetails',

--- a/test/unit/definitions/consented/CaseTypeTab.test.js
+++ b/test/unit/definitions/consented/CaseTypeTab.test.js
@@ -8,6 +8,13 @@ const caseFieldCommon = Object.assign(require('definitions/common/json/CaseField
 const caseFieldAll = caseField.concat(caseFieldCommon);
 const tabIds = uniq(map(caseTypeTab, 'TabID'));
 
+function ignoreMetaDataFields(field, validFields) {
+  if (field.CaseFieldID !== '[STATE]') {
+    return validFields.indexOf(field.CaseFieldID) === -1;
+  }
+  return false;
+}
+
 describe('CaseTypeTab', () => {
   it('should contain a unique case field ID per tab ID (no duplicate field in a tab)', () => {
     const uniqResult = uniqWith(
@@ -53,6 +60,7 @@ describe('CaseTypeTab', () => {
   });
 
   const expected = {
+    State: 1,
     CaseHistoryViewer: 1,
     applicantDetails: 2,
     respondentDetails: 3,
@@ -82,6 +90,7 @@ describe('CaseTypeTab', () => {
   it('should contain a valid Tab IDs', () => {
     expect(tabIds).to.eql([
       'CaseHistoryViewer',
+      'State',
       'applicantDetails',
       'respondentDetails',
       'divorceDetails',
@@ -108,7 +117,7 @@ describe('CaseTypeTab', () => {
   it('should contain a valid case field IDs', () => {
     const validFields = uniq(map(caseFieldAll, 'ID'));
     const objectsWithInvalidCaseId = filter(caseTypeTab, field => {
-      return validFields.indexOf(field.CaseFieldID) === -1;
+      return ignoreMetaDataFields(field, validFields);
     });
     expect(objectsWithInvalidCaseId).to.eql([]);
   });

--- a/test/unit/definitions/contested/CaseTypeTab.test.js
+++ b/test/unit/definitions/contested/CaseTypeTab.test.js
@@ -8,6 +8,13 @@ const caseFieldCommon = Object.assign(require('definitions/common/json/CaseField
 const caseFieldAll = caseField.concat(caseFieldCommon);
 const tabIds = uniq(map(caseTypeTab, 'TabID'));
 
+function ignoreMetaDataFields(field, validFields) {
+  if (field.CaseFieldID !== '[STATE]') {
+    return validFields.indexOf(field.CaseFieldID) === -1;
+  }
+  return false;
+}
+
 describe('CaseTypeTab', () => {
   it('should contain a unique case field ID per tab ID (no duplicate field in a tab)', () => {
     const uniqResult = uniqWith(
@@ -51,6 +58,7 @@ describe('CaseTypeTab', () => {
   });
 
   const expected = {
+    state: 1,
     historyTab: 1,
     applicantDetailsTab: 2,
     divorceDetailsTab: 3,
@@ -85,6 +93,7 @@ describe('CaseTypeTab', () => {
   it('should contain a valid Tab IDs', () => {
     expect(tabIds).to.eql([
       'historyTab',
+      'state',
       'applicantDetailsTab',
       'divorceDetailsTab',
       'respondentDetailsTab',
@@ -115,7 +124,7 @@ describe('CaseTypeTab', () => {
   it('should contain a valid case field IDs', () => {
     const validFields = uniq(map(caseFieldAll, 'ID'));
     const objectsWithInvalidCaseId = filter(caseTypeTab, field => {
-      return validFields.indexOf(field.CaseFieldID) === -1;
+      return ignoreMetaDataFields(field, validFields);
     });
     expect(objectsWithInvalidCaseId).to.eql([]);
   });


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RPET-1016

Resp should no longer be able to view case history, and instead see a 'State' tab, with the 'End State' populating.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
