### PR TITLE
DFR-1007 - AC1. Remove specified events from Judge view when in Ready for Hearin…

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -173,8 +173,8 @@ withPipeline("nodejs", product, component) {
     slackSend(channel: '#finrem-ccd-thread-block', color: 'warning', message: "Master config has been uploaded to AAT. Build details here: <${env.RUN_DISPLAY_URL}|Build ${env.BUILD_DISPLAY_NAME}>.")
   }
 
-  onPR {
-    enableCleanupOfHelmReleaseOnSuccess()
-  }
+//  onPR {
+//    enableCleanupOfHelmReleaseOnSuccess()
+//  }
 }
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -173,8 +173,8 @@ withPipeline("nodejs", product, component) {
     slackSend(channel: '#finrem-ccd-thread-block', color: 'warning', message: "Master config has been uploaded to AAT. Build details here: <${env.RUN_DISPLAY_URL}|Build ${env.BUILD_DISPLAY_NAME}>.")
   }
 
-//  onPR {
-//    enableCleanupOfHelmReleaseOnSuccess()
-//  }
+  onPR {
+    enableCleanupOfHelmReleaseOnSuccess()
+  }
 }
 

--- a/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -872,7 +872,7 @@
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_judgeToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-judiciary",
-    "CRUD": "CR"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -872,14 +872,14 @@
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_judgeToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-judiciary",
-    "CRUD": "CR"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_solicitorToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-judiciary",
-    "CRUD": "CR"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -879,7 +879,7 @@
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_solicitorToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-judiciary",
-    "CRUD": "R"
+    "CRUD": "CR"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -214,14 +214,14 @@
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_judgeToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-solicitor",
-    "CRUD": "CR"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_solicitorToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-solicitor",
-    "CRUD": "CR"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -879,7 +879,7 @@
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_solicitorToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-judiciary",
-    "CRUD": "CR"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -879,7 +879,7 @@
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_solicitorToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-judiciary",
-    "CRUD": "CR"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -221,7 +221,7 @@
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_solicitorToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-solicitor",
-    "CRUD": "R"
+    "CRUD": "CR"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -221,7 +221,7 @@
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_solicitorToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-solicitor",
-    "CRUD": "CR"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -214,14 +214,14 @@
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_judgeToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-solicitor",
-    "CRUD": "R"
+    "CRUD": "CR"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_solicitorToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-solicitor",
-    "CRUD": "R"
+    "CRUD": "CR"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -872,14 +872,14 @@
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_judgeToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-judiciary",
-    "CRUD": "R"
+    "CRUD": "CR"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_solicitorToDraftOrder",
     "UserRole": "caseworker-divorce-financialremedy-judiciary",
-    "CRUD": "R"
+    "CRUD": "CR"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/contested/json/CaseEvent/CaseEvent.json
+++ b/definitions/contested/json/CaseEvent/CaseEvent.json
@@ -384,8 +384,8 @@
     "Name": "Upload Draft Order",
     "Description": "Upload Draft Order",
     "DisplayOrder": 32,
-    "PreConditionState(s)": "solicitorDraftOrder",
-    "PostConditionState": "caseFileSubmitted",
+    "PreConditionState(s)": "caseFileSubmitted",
+    "PostConditionState": "reviewOrder",
     "SecurityClassification": "Public",
     "ShowSummary": "Y",
     "ShowEventNotes": "N"

--- a/definitions/contested/json/CaseEvent/CaseEvent.json
+++ b/definitions/contested/json/CaseEvent/CaseEvent.json
@@ -385,7 +385,7 @@
     "Description": "Upload Draft Order",
     "DisplayOrder": 32,
     "PreConditionState(s)": "solicitorDraftOrder",
-    "PostConditionState": "reviewOrder",
+    "PostConditionState": "caseFileSubmitted",
     "SecurityClassification": "Public",
     "ShowSummary": "Y",
     "ShowEventNotes": "N"

--- a/definitions/contested/json/CaseEvent/CaseEvent.json
+++ b/definitions/contested/json/CaseEvent/CaseEvent.json
@@ -370,7 +370,6 @@
     "Name": "Solicitor To Draft Order",
     "Description": "Solicitor To Draft Order",
     "DisplayOrder": 31,
-    "PreConditionState(s)": "caseFileSubmitted",
     "PostConditionState": "solicitorDraftOrder",
     "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/case-orchestration/notify/draft-order",
     "SecurityClassification": "Public",

--- a/definitions/contested/json/CaseEvent/CaseEvent.json
+++ b/definitions/contested/json/CaseEvent/CaseEvent.json
@@ -370,6 +370,7 @@
     "Name": "Solicitor To Draft Order",
     "Description": "Solicitor To Draft Order",
     "DisplayOrder": 31,
+    "PreConditionState(s)": "caseFileSubmitted",
     "PostConditionState": "solicitorDraftOrder",
     "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/case-orchestration/notify/draft-order",
     "SecurityClassification": "Public",

--- a/test/functional/contested_test.js
+++ b/test/functional/contested_test.js
@@ -94,7 +94,7 @@ Scenario('Contested Case Approved and Send Order @nightly @pipeline @crossBrowse
   const allocationDirections = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_giveAllocationDirections', './test/data/ccd-contested-allocation-directions.json');
   const listForHearing = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_addSchedulingListingInfo', './test/data/ccd-contested-list-for-hearing.json');
   const submitUploadCaseFiles = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_submitUploadedCaseFiles', './test/data/ccd-contested-list-for-hearing.json');
-  const solicitorToDraftOrder = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_solicitorToDraftOrder', './test/data/ccd-contested-solicitor-draft-order.json');
+ // const solicitorToDraftOrder = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_solicitorToDraftOrder', './test/data/ccd-contested-solicitor-draft-order.json');
   const solicitorDraftDirectionOrder = await updateCaseInCcd(solicitorUserName, solicitorPassword, caseId, 'FinancialRemedyContested', 'FR_solicitorDraftDirectionOrder', './test/data/ccd-contested-solicitor-draft-direction-order.json');
   const draftOrderApproved = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_draftOrderApproved', './test/data/ccd-contested-judge-approved.json');
   const uploadOrder = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_directionOrder', './test/data/ccd-contested-caseworker-upload-order.json');

--- a/test/functional/contested_test.js
+++ b/test/functional/contested_test.js
@@ -94,8 +94,8 @@ Scenario('Contested Case Approved and Send Order @nightly @pipeline @crossBrowse
   const allocationDirections = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_giveAllocationDirections', './test/data/ccd-contested-allocation-directions.json');
   const listForHearing = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_addSchedulingListingInfo', './test/data/ccd-contested-list-for-hearing.json');
   const submitUploadCaseFiles = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_submitUploadedCaseFiles', './test/data/ccd-contested-list-for-hearing.json');
- // const solicitorToDraftOrder = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_solicitorToDraftOrder', './test/data/ccd-contested-solicitor-draft-order.json');
-  const solicitorDraftDirectionOrder = await updateCaseInCcd(solicitorUserName, solicitorPassword, caseId, 'FinancialRemedyContested', 'FR_solicitorDraftDirectionOrder', './test/data/ccd-contested-solicitor-draft-direction-order.json');
+  const solicitorToDraftOrder = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_solicitorToDraftOrder', './test/data/ccd-contested-solicitor-draft-order.json');
+  //const solicitorDraftDirectionOrder = await updateCaseInCcd(solicitorUserName, solicitorPassword, caseId, 'FinancialRemedyContested', 'FR_solicitorDraftDirectionOrder', './test/data/ccd-contested-solicitor-draft-direction-order.json');
   const draftOrderApproved = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_draftOrderApproved', './test/data/ccd-contested-judge-approved.json');
   const uploadOrder = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_directionOrder', './test/data/ccd-contested-caseworker-upload-order.json');
   const sendOrder = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_sendOrder', './test/data/ccd-caseworker-send-order.json');

--- a/test/functional/contested_test.js
+++ b/test/functional/contested_test.js
@@ -94,6 +94,7 @@ Scenario('Contested Case Approved and Send Order @nightly @pipeline @crossBrowse
   const allocationDirections = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_giveAllocationDirections', './test/data/ccd-contested-allocation-directions.json');
   const listForHearing = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_addSchedulingListingInfo', './test/data/ccd-contested-list-for-hearing.json');
   const submitUploadCaseFiles = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_submitUploadedCaseFiles', './test/data/ccd-contested-list-for-hearing.json');
+  const solicitorToDraftOrder = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_solicitorToDraftOrder', './test/data/ccd-contested-solicitor-draft-order.json');
   const solicitorDraftDirectionOrder = await updateCaseInCcd(solicitorUserName, solicitorPassword, caseId, 'FinancialRemedyContested', 'FR_solicitorDraftDirectionOrder', './test/data/ccd-contested-solicitor-draft-direction-order.json');
   const draftOrderApproved = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_draftOrderApproved', './test/data/ccd-contested-judge-approved.json');
   const uploadOrder = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_directionOrder', './test/data/ccd-contested-caseworker-upload-order.json');

--- a/test/functional/contested_test.js
+++ b/test/functional/contested_test.js
@@ -94,7 +94,6 @@ Scenario('Contested Case Approved and Send Order @nightly @pipeline @crossBrowse
   const allocationDirections = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_giveAllocationDirections', './test/data/ccd-contested-allocation-directions.json');
   const listForHearing = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_addSchedulingListingInfo', './test/data/ccd-contested-list-for-hearing.json');
   const submitUploadCaseFiles = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_submitUploadedCaseFiles', './test/data/ccd-contested-list-for-hearing.json');
-  const solicitorToDraftOrder = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_solicitorToDraftOrder', './test/data/ccd-contested-solicitor-draft-order.json');
   const solicitorDraftDirectionOrder = await updateCaseInCcd(solicitorUserName, solicitorPassword, caseId, 'FinancialRemedyContested', 'FR_solicitorDraftDirectionOrder', './test/data/ccd-contested-solicitor-draft-direction-order.json');
   const draftOrderApproved = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_draftOrderApproved', './test/data/ccd-contested-judge-approved.json');
   const uploadOrder = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_directionOrder', './test/data/ccd-contested-caseworker-upload-order.json');

--- a/test/functional/contested_test.js
+++ b/test/functional/contested_test.js
@@ -95,7 +95,7 @@ Scenario('Contested Case Approved and Send Order @nightly @pipeline @crossBrowse
   const listForHearing = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_addSchedulingListingInfo', './test/data/ccd-contested-list-for-hearing.json');
   const submitUploadCaseFiles = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_submitUploadedCaseFiles', './test/data/ccd-contested-list-for-hearing.json');
   const solicitorToDraftOrder = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_solicitorToDraftOrder', './test/data/ccd-contested-solicitor-draft-order.json');
-  //const solicitorDraftDirectionOrder = await updateCaseInCcd(solicitorUserName, solicitorPassword, caseId, 'FinancialRemedyContested', 'FR_solicitorDraftDirectionOrder', './test/data/ccd-contested-solicitor-draft-direction-order.json');
+  const solicitorDraftDirectionOrder = await updateCaseInCcd(solicitorUserName, solicitorPassword, caseId, 'FinancialRemedyContested', 'FR_solicitorDraftDirectionOrder', './test/data/ccd-contested-solicitor-draft-direction-order.json');
   const draftOrderApproved = await updateCaseInCcd(judgeUserName, judgePassword, caseId, 'FinancialRemedyContested', 'FR_draftOrderApproved', './test/data/ccd-contested-judge-approved.json');
   const uploadOrder = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_directionOrder', './test/data/ccd-contested-caseworker-upload-order.json');
   const sendOrder = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'FinancialRemedyContested', 'FR_sendOrder', './test/data/ccd-caseworker-send-order.json');


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFR-1007

### Change description ###

The Judge can run the following two events from the Ready for Hearing state:

a. Judge to Draft Order (FR_judgeToDraftOrder)
b. Solicitor to Draft Order (FR_solicitorToDraftOrder)

For acceptance criteria 1: Requirement 1 is to remove the above mentioned events from being visible (and therefore available) to the Judge to run from the Ready for Hearing state

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
