### PR TITLE
DFR-1171: allow letter N or J in lower case in  Judicial Separation a…

### DIFF
--- a/definitions/consented/json/CaseField/CaseField.json
+++ b/definitions/consented/json/CaseField/CaseField.json
@@ -184,7 +184,7 @@
     "Label": "Divorce / Dissolution Case Number",
     "HintText": "Enter 10 character alphanumeric divorce case number",
     "FieldType": "Text",
-    "RegularExpression": "^([A-Z|a-z][A-Z|a-z])\\d{2}[D|d]\\d{5}$|^([A-Z|a-z][A-Z|a-z])\\d{2}[J|d]\\d{5}$|^([A-Z|a-z][A-Z|a-z])\\d{2}[N|d]\\d{5}$|\\b\\d{4}[ -]\\d{4}[ -]\\d{4}[ -]\\d{4}\\b|\\b\\d{4}\\d{4}\\d{4}\\d{4}\\b",
+    "RegularExpression": "^([A-Z|a-z][A-Z|a-z])\\d{2}[D|d]\\d{5}$|^([A-Z|a-z][A-Z|a-z])\\d{2}[J|j]\\d{5}$|^([A-Z|a-z][A-Z|a-z])\\d{2}[N|n]\\d{5}$|\\b\\d{4}[ -]\\d{4}[ -]\\d{4}[ -]\\d{4}\\b|\\b\\d{4}\\d{4}\\d{4}\\d{4}\\b",
     "SecurityClassification": "Public"
   },
   {

--- a/definitions/contested/json/CaseField/CaseField.json
+++ b/definitions/contested/json/CaseField/CaseField.json
@@ -182,7 +182,7 @@
     "Label": "Divorce / Dissolution Case Number",
     "HintText": "Enter 10 character alphanumeric divorce case number",
     "FieldType": "Text",
-    "RegularExpression": "^([A-Z|a-z][A-Z|a-z])\\d{2}[D|d]\\d{5}$|^([A-Z|a-z][A-Z|a-z])\\d{2}[J|d]\\d{5}$|^([A-Z|a-z][A-Z|a-z])\\d{2}[N|d]\\d{5}$|\\b\\d{4}[ -]\\d{4}[ -]\\d{4}[ -]\\d{4}\\b|\\b\\d{4}\\d{4}\\d{4}\\d{4}\\b",
+    "RegularExpression": "^([A-Z|a-z][A-Z|a-z])\\d{2}[D|d]\\d{5}$|^([A-Z|a-z][A-Z|a-z])\\d{2}[J|j]\\d{5}$|^([A-Z|a-z][A-Z|a-z])\\d{2}[N|n]\\d{5}$|\\b\\d{4}[ -]\\d{4}[ -]\\d{4}[ -]\\d{4}\\b|\\b\\d{4}\\d{4}\\d{4}\\d{4}\\b",
     "SecurityClassification": "Public"
   },
   {


### PR DESCRIPTION


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFR-1171


### Change description ###
we allowed Judicial Separation and Nullity case numbers to be accepted in FR when cases are created. This change only allowed cases to be entered with a capital N or J. It would be easier for caseworkers to enter cases if it also accepted lower case "n" and "j".


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
