### PR TITLE
Enable preview environment builds to set finrem-cos image using GitHub label

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -96,6 +96,14 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
   ]
 }
 
+def getFinremCosImage() {
+  def githubApi = new GithubAPI(this)
+  for (label in githubApi.getLabelsbyPattern(env.BRANCH_NAME, "use-finrem-cos-pr-") ) {
+    return label.minus("use-finrem-cos-")
+  }
+  return "latest"
+}
+
 // Configure branches to sync with master branch
 def branchesToSync = ['demo', 'ithc', 'perftest']
 properties([
@@ -203,6 +211,7 @@ withPipeline("nodejs", product, component) {
 
   onPR() {
     env.ENV='preview'
+    env.FINREM_COS_IMAGE = getFinremCosImage()
   }
 
   onIthc() {

--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ https://tools.hmcts.net/confluence/display/FR/Feature+toggles+for+CCD+definition
 
 A PR will create a full CCD/ExUI stack in the preview environment as defined in the [Helm chart](charts/finrem-ccd-definitions/values.preview.template.yaml).
 
+If you require a particular finrem-cos PR image rather than the latest production image then you should specify this
+using a GitHub label. Add a label `use-finrem-cos-pr-number` replacing `number` with the value required.
+
 GitHub will have the main URL for a PR deployment. e.g. `https://finrem-ccd-definitions-pr-<number>.preview.platform.hmcts.net/`
 
 This can be found be clicking 'View Deployment' in the conversation tab of the PR. However, this URL in itself is not very useful.

--- a/charts/finrem-ccd-definitions/values.preview.template.yaml
+++ b/charts/finrem-ccd-definitions/values.preview.template.yaml
@@ -55,7 +55,7 @@ finrem-cos:
   enabled: true
   java:
     imagePullPolicy: Always
-    image: hmctspublic.azurecr.io/finrem/cos:latest
+    image: hmctspublic.azurecr.io/finrem/cos:${FINREM_COS_IMAGE}
     releaseNameOverride: ${SERVICE_NAME}-finrem-cos
     ingressHost: cos-${SERVICE_FQDN}
     environment:


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DFR-2968


### Change description ###
Enable preview environment builds to set finrem-cos image using GitHub label

