### PR TITLE
Bump azure identity due to CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,8 @@
     "tar": "^7.0.0",
     "phin": "^3.7.1",
     "formidable": "^3.5.1",
-    "braces": "^3.0.3"
+    "braces": "^3.0.3",
+    "@azure/identity": "^4.2.1"
   },
   "packageManager": "yarn@3.8.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,9 +133,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/identity@npm:^4.0.0-beta.1":
-  version: 4.0.1
-  resolution: "@azure/identity@npm:4.0.1"
+"@azure/identity@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@azure/identity@npm:4.2.1"
   dependencies:
     "@azure/abort-controller": ^1.0.0
     "@azure/core-auth": ^1.5.0
@@ -144,14 +144,14 @@ __metadata:
     "@azure/core-tracing": ^1.0.0
     "@azure/core-util": ^1.3.0
     "@azure/logger": ^1.0.0
-    "@azure/msal-browser": ^3.5.0
-    "@azure/msal-node": ^2.5.1
+    "@azure/msal-browser": ^3.11.1
+    "@azure/msal-node": ^2.9.2
     events: ^3.0.0
     jws: ^4.0.0
     open: ^8.0.0
     stoppable: ^1.1.0
     tslib: ^2.2.0
-  checksum: 2c975ca70b274dc185022c2b19f1774079fd5cfb08c78ec3500e4baf973911b2958031d5fa36369d3c9acdeb25db457cc497991e7393b383103c058e097703e5
+  checksum: 2dbd7b0fa6b92904b7b8f828374d7316384cc4e00c71cdac3a2f2544b9e02c7287fe7ad58149bb8794c57913d77a927f5a7b5d1367e05abe82b0f2e1b162415c
   languageName: node
   linkType: hard
 
@@ -183,30 +183,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/msal-browser@npm:^3.5.0":
-  version: 3.9.0
-  resolution: "@azure/msal-browser@npm:3.9.0"
+"@azure/msal-browser@npm:^3.11.1":
+  version: 3.17.0
+  resolution: "@azure/msal-browser@npm:3.17.0"
   dependencies:
-    "@azure/msal-common": 14.7.0
-  checksum: e4dfc4353933fbec545cde050bc6cd23773ff07f6cf69f730a6b27b51f99f7a235acccc6ec1f1dad030a2a078088701d748e3e508f260209693dd78ad7870fba
+    "@azure/msal-common": 14.12.0
+  checksum: 4b01ee3500e5bb1c8a71e92b81f61174d23109eb60101c17bf95ede248eeefd2ca5d68228d7d1cf147eeeade5bbe994a09f8ada96e14f3352da7822899c0c441
   languageName: node
   linkType: hard
 
-"@azure/msal-common@npm:14.7.0":
-  version: 14.7.0
-  resolution: "@azure/msal-common@npm:14.7.0"
-  checksum: a7c291da9f9778a9dd3027d675de856deb27fc0b6ef63f9f48a221b8f659752d6b820fc9e629e4e39a2e89c2d48eb4dc68797da4420eec12f360dd3627f60def
+"@azure/msal-common@npm:14.12.0":
+  version: 14.12.0
+  resolution: "@azure/msal-common@npm:14.12.0"
+  checksum: 9a987b7b9b6453500481ec48224b4d9f728c62ac584f9a35ef519eff46016fc63c1a7dc159f725a5ec3748bf1ade352654fd7a7170ba42bc27ca263a01cf59db
   languageName: node
   linkType: hard
 
-"@azure/msal-node@npm:^2.5.1":
-  version: 2.6.3
-  resolution: "@azure/msal-node@npm:2.6.3"
+"@azure/msal-node@npm:^2.9.2":
+  version: 2.9.2
+  resolution: "@azure/msal-node@npm:2.9.2"
   dependencies:
-    "@azure/msal-common": 14.7.0
+    "@azure/msal-common": 14.12.0
     jsonwebtoken: ^9.0.0
     uuid: ^8.3.0
-  checksum: 6b8299ff9bb5aa042f8873aa65247a1754d3156a37e0e99a87c935c3f11b02bb9152cfb0198f88c27ef488548e2f16e5eebf4d533e5d08e818395aaa9d81d1fa
+  checksum: a2b51d4085d20cbac84752b9e68a5a22c7c9dbfdbc25a1713ee5e6918a504928f82e66c9317fc78db4f12053e7debd477b984cab578e0bea269aacc0862e7219
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Change description ###
Bump azure identity due to CVE.
This dependency is from  "@hmcts/properties-volume": "1.1.0",
