### PR TITLE
Increase ccd-definition-store transaction timeout

### DIFF
--- a/charts/finrem-ccd-definitions/values.preview.template.yaml
+++ b/charts/finrem-ccd-definitions/values.preview.template.yaml
@@ -212,6 +212,7 @@ ccd:
         DEFINITION_STORE_DB_HOST: '{{ tpl .Values.global.postgresHostname $}}'
         DEFINITION_STORE_IDAM_KEY: ${DEFINITION_STORE_S2S_KEY}
         DEFINITION_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_admin,aac_manage_case_assignment
+        DEFINITION_STORE_TX_TIMEOUT_DEFAULT: 180
         IDAM_USER_URL: https://idam-web-public.aat.platform.hmcts.net
         OIDC_ISSUER: https://forgerock-am.service.core-compute-idam-aat.internal:8443/openam/oauth2/hmcts
         WELSH_TRANSLATION_ENABLED: false


### PR DESCRIPTION
### Change description ###
Increase ccd-definition-store transaction timeout (value in seconds).
This is required because timeouts are occurring during the CCD definition file import process in preview.

