### PR TITLE
Fix Jenkinsfile_nightly

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -101,7 +101,7 @@ withNightlyPipeline(type, product, component) {
                 steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/tests/functionalTest/**/*'
             }
         }
-        
+    }
     // Webkit step removed until run stabilized 
 
     //     stage('Functional playwright tests - webkit') {


### PR DESCRIPTION
### Change description

Fix error in nightly pipeline:

08:30:28  Obtained Jenkinsfile_nightly from 5e3ce386b8cb7ec8f2184f3fb2a2f3bcfcf46293
08:30:28  org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
08:30:28  WorkflowScript: 126: expecting '}', found '' @ line 126, column 1.
08:30:28  1 error
