### PR TITLE
DFR-3083: Including refuge fields in court admin update contact detai…

### DIFF
--- a/definitions/contested/json/CaseEventToFields/Refuge-nonprod.json
+++ b/definitions/contested/json/CaseEventToFields/Refuge-nonprod.json
@@ -22,5 +22,28 @@
     "PageDisplayOrder": 7,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y"
+  },
+  {
+    "LiveFrom": "12/12/2024",
+    "CaseTypeID": "FinancialRemedyContested",
+    "CaseEventID": "FR_updateContactDetails",
+    "CaseFieldID": "applicantInRefugeQuestion",
+    "PageFieldDisplayOrder": 10,
+    "DisplayContext": "OPTIONAL",
+    "PageID": 3,
+    "PageDisplayOrder": 3,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "Y"
+  },
+  {
+    "LiveFrom": "12/12/2024",
+    "CaseTypeID": "FinancialRemedyContested",
+    "CaseEventID": "FR_updateContactDetails",
+    "CaseFieldID": "respondentInRefugeQuestion",
+    "PageFieldDisplayOrder": 10,
+    "DisplayContext": "OPTIONAL",
+    "PageDisplayOrder": 5,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "Y"
   }
 ]

--- a/definitions/contested/json/CaseEventToFields/Refuge-nonprod.json
+++ b/definitions/contested/json/CaseEventToFields/Refuge-nonprod.json
@@ -42,6 +42,7 @@
     "CaseFieldID": "respondentInRefugeQuestion",
     "PageFieldDisplayOrder": 10,
     "DisplayContext": "OPTIONAL",
+    "PageID": 5,
     "PageDisplayOrder": 5,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3083

### Change description

Including refuge fields in the court admin's Update contact details event.  Only a court admin can amend refuge fields in an update contact details event.

### Testing done

Manual testing of the scenarios.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
