### PR TITLE
DFR-3478: Prevent duplication of additional documents

### DIFF
--- a/definitions/contested/json/CaseEventToFields/CaseEventToFields.json
+++ b/definitions/contested/json/CaseEventToFields/CaseEventToFields.json
@@ -9731,19 +9731,6 @@
     "RetriesTimeoutURLMidEvent": "3,4,5"
   },
   {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "FinancialRemedyContested",
-    "CaseEventID": "FR_uploadApprovedOrder",
-    "CaseFieldID": "uploadAdditionalDocument",
-    "PageFieldDisplayOrder": 2,
-    "DisplayContext": "OPTIONAL",
-    "PageID": 1,
-    "PageDisplayOrder": 1,
-    "PageColumnNumber": 1,
-    "FieldShowCondition": "uploadHearingOrder=\"DONOTSHOW\"",
-    "ShowSummaryChangeOption": "Y"
-  },
-  {
     "LiveFrom": "01/01/2021",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_uploadApprovedOrder",


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3478

### Change description

Remove hidden (and unneeded) field that is no longer used in the Upload Approved Order event.
