### PR TITLE
DFR-3487: Draft orders - remove consent order link for interveners

### DIFF
--- a/definitions/contested/json/AuthorisationCaseField/DraftOrders-nonprod.json
+++ b/definitions/contested/json/AuthorisationCaseField/DraftOrders-nonprod.json
@@ -133,17 +133,31 @@
     "CRUD": "R"
   },
   {
+    "LiveFrom": "31/12/2024",
+    "CaseTypeID": "FinancialRemedyContested",
+    "CaseFieldID": "consentApplicationGuidanceText",
+    "UserRole": "caseworker-divorce-financialremedy-courtadmin",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "31/12/2024",
+    "CaseTypeID": "FinancialRemedyContested",
+    "CaseFieldID": "consentApplicationGuidanceText",
+    "UserRole": "caseworker-divorce-financialremedy-solicitor",
+    "CRUD": "CRU"
+  },
+  {
     "LiveFrom": "29/10/2024",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseFieldID": "consentApplicationGuidance",
     "UserRole": "caseworker-divorce-financialremedy-courtadmin",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "29/10/2024",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseFieldID": "consentApplicationGuidance",
     "UserRole": "caseworker-divorce-financialremedy-solicitor",
-    "CRUD": "R"
+    "CRUD": "CRU"
   }
 ]

--- a/definitions/contested/json/CaseEventToFields/DraftOrders-nonprod.json
+++ b/definitions/contested/json/CaseEventToFields/DraftOrders-nonprod.json
@@ -71,11 +71,24 @@
     "FieldShowCondition": "[STATE]=\"applicationIssued\" OR [STATE]=\"schedulingAndHearing\" OR [STATE]=\"prepareForHearing\" OR [STATE]=\"solicitorDraftOrder\" OR [STATE]=\"judgeDraftOrder\" OR [STATE]=\"draftOrderNotApproved\" OR [STATE]=\"scheduleRaiseDirectionsOrder\" OR [STATE]=\"orderDrawn\" OR [STATE]=\"caseWorkerReview\" OR [STATE]=\"gateKeepingAndAllocation\" OR [STATE]=\"caseFileSubmitted\" OR [STATE]=\"reviewOrder\" OR [STATE]=\"awaitingJudiciaryResponse\" OR [STATE]=\"close\" OR [STATE]=\"orderSent\" OR [STATE]=\"generalApplication\" OR [STATE]=\"generalApplicationOutcome\""
   },
   {
+    "LiveFrom": "31/12/2024",
+    "CaseTypeID": "FinancialRemedyContested",
+    "CaseEventID": "FR_draftOrders",
+    "CaseFieldID": "consentApplicationGuidanceText",
+    "PageFieldDisplayOrder": 3,
+    "DisplayContext": "MANDATORY",
+    "PageID": 1,
+    "PageLabel": "Upload draft orders",
+    "PageDisplayOrder": 1,
+    "PageColumnNumber": 1,
+    "FieldShowCondition": "generalApplicationGuidance=\"DONOTSHOW\""
+  },
+  {
     "LiveFrom": "29/10/2024",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_draftOrders",
     "CaseFieldID": "consentApplicationGuidance",
-    "PageFieldDisplayOrder": 3,
+    "PageFieldDisplayOrder": 4,
     "DisplayContext": "READONLY",
     "PageID": 1,
     "PageLabel": "Upload draft orders",

--- a/definitions/contested/json/CaseEventToFields/DraftOrders-nonprod.json
+++ b/definitions/contested/json/CaseEventToFields/DraftOrders-nonprod.json
@@ -7,7 +7,7 @@
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "MANDATORY",
     "PageID": 1,
-    "PageLabel": "Upload draft order(s)",
+    "PageLabel": "Upload draft orders",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y"
@@ -20,7 +20,7 @@
     "PageFieldDisplayOrder": 2,
     "DisplayContext": "MANDATORY",
     "PageID": 1,
-    "PageLabel": "Upload draft order(s)",
+    "PageLabel": "Upload draft orders",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
     "FieldShowCondition": "typeOfDraftOrder=\"never show\"",
@@ -35,7 +35,7 @@
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "COMPLEX",
     "PageID": 2,
-    "PageLabel": "Upload draft order(s)",
+    "PageLabel": "Upload draft orders",
     "PageDisplayOrder": 2,
     "PageColumnNumber": 1,
     "PageShowCondition": "typeOfDraftOrder=\"aSuggestedDraftOrderPriorToAListedHearing\"",
@@ -50,7 +50,7 @@
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "COMPLEX",
     "PageID": 3,
-    "PageLabel": "Upload draft order(s)",
+    "PageLabel": "Upload draft orders",
     "PageDisplayOrder": 3,
     "PageColumnNumber": 1,
     "PageShowCondition": "typeOfDraftOrder=\"anAgreedOrderFollowingAHearing\"",
@@ -65,7 +65,7 @@
     "PageFieldDisplayOrder": 2,
     "DisplayContext": "READONLY",
     "PageID": 1,
-    "PageLabel": "Upload draft order(s)",
+    "PageLabel": "Upload draft orders",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
     "FieldShowCondition": "[STATE]=\"applicationIssued\" OR [STATE]=\"schedulingAndHearing\" OR [STATE]=\"prepareForHearing\" OR [STATE]=\"solicitorDraftOrder\" OR [STATE]=\"judgeDraftOrder\" OR [STATE]=\"draftOrderNotApproved\" OR [STATE]=\"scheduleRaiseDirectionsOrder\" OR [STATE]=\"orderDrawn\" OR [STATE]=\"caseWorkerReview\" OR [STATE]=\"gateKeepingAndAllocation\" OR [STATE]=\"caseFileSubmitted\" OR [STATE]=\"reviewOrder\" OR [STATE]=\"awaitingJudiciaryResponse\" OR [STATE]=\"close\" OR [STATE]=\"orderSent\" OR [STATE]=\"generalApplication\" OR [STATE]=\"generalApplicationOutcome\""
@@ -78,7 +78,7 @@
     "PageFieldDisplayOrder": 3,
     "DisplayContext": "READONLY",
     "PageID": 1,
-    "PageLabel": "Upload draft order(s)",
+    "PageLabel": "Upload draft orders",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1
   }

--- a/definitions/contested/json/CaseField/DraftOrders-nonprod.json
+++ b/definitions/contested/json/CaseField/DraftOrders-nonprod.json
@@ -22,7 +22,7 @@
     "LiveFrom": "29/10/2024",
     "CaseTypeID": "FinancialRemedyContested",
     "ID": "uploadSuggestedDraftOrder",
-    "Label": "Upload Suggested Draft Order",
+    "Label": "Upload draft orders",
     "FieldType": "FR_uploadSuggestedDraftOrder",
     "SecurityClassification": "Public",
     "Searchable": "N"
@@ -31,7 +31,7 @@
     "LiveFrom": "29/10/2024",
     "CaseTypeID": "FinancialRemedyContested",
     "ID": "uploadAgreedDraftOrder",
-    "Label": "Upload Agreed Draft Order",
+    "Label": "Upload agreed draft orders",
     "FieldType": "FR_uploadAgreedDraftOrder",
     "SecurityClassification": "Public",
     "Searchable": "N"

--- a/definitions/contested/json/CaseField/DraftOrders-nonprod.json
+++ b/definitions/contested/json/CaseField/DraftOrders-nonprod.json
@@ -84,10 +84,19 @@
     "SecurityClassification": "Public"
   },
   {
+    "LiveFrom": "31/12/2024",
+    "CaseTypeID": "FinancialRemedyContested",
+    "ID": "consentApplicationGuidanceText",
+    "Label": " ",
+    "FieldType": "Text",
+    "SecurityClassification": "Public",
+    "Searchable": "N"
+  },
+  {
     "LiveFrom": "29/10/2024",
     "CaseTypeID": "FinancialRemedyContested",
     "ID": "consentApplicationGuidance",
-    "Label": "Use the '<a href=\"/cases/case-details/${[CASE_REFERENCE]}/trigger/FR_consentOrder/FR_consentOrder1\">consent order</a>' event if you need to upload a consent order to finalise the contested proceedings.",
+    "Label": "${consentApplicationGuidanceText}",
     "FieldType": "Label",
     "SecurityClassification": "Public"
   }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3487

### Change description

Remove link to consent order event for intervenevers.

As the link is still required for other users the text shown on screen is now created in Java code and displayed using field interpolation
