### PR TITLE
DFR-3596: Fixed local court initialisation in Playwright test

### DIFF
--- a/playwright-e2e/functional/consented/create_case.spec.ts
+++ b/playwright-e2e/functional/consented/create_case.spec.ts
@@ -50,7 +50,7 @@ test(
 
     //applicant details
     await applicantDetailsPage.enterApplicantDetailsConsented('Frodo', 'Baggins');
-    await financialRemedyCourtPage.selectCourtZoneDropDown();
+    await financialRemedyCourtPage.selectCourtZoneDropDown('DERBY COMBINED COURT CENTRE');
     await applicantDetailsPage.navigateContinue();
 
     //respondent details


### PR DESCRIPTION
### Jira link

DFR-3596

### Change description

Earlier DFR-3596 change refactored how local court dropdowns were selected by Playwright testing. I amended and locally tested for all contested cases.  Didn't change for consented.  Issue picked up in the Nightly run.

### Testing done

Local running.
Manually checked that all calls to selectCourtZoneDropDown included a valid court param.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
