### PR TITLE
DFR-3623: 

### DIFF
--- a/definitions/contested/json/CaseEventToFields/CaseEventToFields.json
+++ b/definitions/contested/json/CaseEventToFields/CaseEventToFields.json
@@ -1309,7 +1309,7 @@
     "PageID": 15,
     "PageDisplayOrder": 15,
     "PageColumnNumber": 1,
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/case-orchestration/ccdMidEvent",
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/case-orchestration/contested/set-frc-details",
     "ShowSummaryChangeOption": "Y"
   },
   {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@hmcts/properties-volume": "1.2.0",
     "@typescript-eslint/eslint-plugin": "^8.13.0",
     "@typescript-eslint/parser": "^8.13.0",
-    "axios": "^1.7.4",
+    "axios": "^1.8.2",
     "codeceptjs": "^3.6.7",
     "config": "^3.3.12",
     "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,8 @@
   "resolutions": {
     "cross-spawn": "^7.0.6",
     "puppeteer-core": "^24.0.0",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "axios": "^1.8.2"
   },
   "packageManager": "yarn@3.8.7"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2791,17 +2791,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.7.7":
-  version: 1.7.7
-  resolution: "axios@npm:1.7.7"
-  dependencies:
-    follow-redirects: ^1.15.6
-    form-data: ^4.0.0
-    proxy-from-env: ^1.1.0
-  checksum: 882d4fe0ec694a07c7f5c1f68205eb6dc5a62aecdb632cc7a4a3d0985188ce3030e0b277e1a8260ac3f194d314ae342117660a151fabffdc5081ca0b5a8b47fe
-  languageName: node
-  linkType: hard
-
 "axios@npm:^1.8.2":
   version: 1.8.2
   resolution: "axios@npm:1.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,7 +2802,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.7.4":
+"axios@npm:^1.8.2":
   version: 1.8.2
   resolution: "axios@npm:1.8.2"
   dependencies:
@@ -5456,7 +5456,7 @@ __metadata:
     "@types/node": ^22.0.0
     "@typescript-eslint/eslint-plugin": ^8.13.0
     "@typescript-eslint/parser": ^8.13.0
-    axios: ^1.7.4
+    axios: ^1.8.2
     chai: ^4.5.0
     codeceptjs: ^3.6.7
     config: ^3.3.12


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3623

### Change description

Reverting what was merged with https://github.com/hmcts/finrem-ccd-definitions/pull/2370

Pointing the court selection page at the old controller method, until it's new handler replacement includes validation to stop High Court or Royal Court of Justice being chosen from the court selection screen.

The old controller method is still there, as it's still used by other contested events.
Updated Playwright tests will still pass, they make sure the court info shows - which it does.

### Testing done

Manually tested in Preview.  Have confirmed that the validation is restored and that the selected court fields are still being set.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
