### PR TITLE
DFR-3677: Change Draft orders tab show condition to handle existing cases

### DIFF
--- a/definitions/contested/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/contested/json/CaseTypeTab/CaseTypeTab.json
@@ -4209,7 +4209,7 @@
     "TabLabel": "Draft orders",
     "TabDisplayOrder": 17,
     "CaseFieldID": "draftOrdersReviewCollection",
-    "TabShowCondition": "isUnreviewedDocumentPresent=\"Yes\"",
+    "TabShowCondition": "isUnreviewedDocumentPresent!=\"No\"",
     "UserRole": "caseworker-divorce-financialremedy-courtadmin",
     "TabFieldDisplayOrder": 1
   },
@@ -4240,7 +4240,7 @@
     "TabLabel": "Draft orders",
     "TabDisplayOrder": 17,
     "CaseFieldID": "draftOrdersReviewCollection",
-    "TabShowCondition": "isUnreviewedDocumentPresent=\"Yes\"",
+    "TabShowCondition": "isUnreviewedDocumentPresent!=\"No\"",
     "TabFieldDisplayOrder": 2
   },
   {


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3677

### Change description

Fix for https://tools.hmcts.net/jira/browse/DFR-3550 only works with newly uploaded draft orders.
Cases with existing draft orders no longer show the Draft orders tab.
Change the tab show condition to handle cases with no value set for isUnreviewedDocumentPresent

