### PR TITLE
DFR-3644-3645 follow up auth fix so that labels show in AAT

### DIFF
--- a/definitions/contested/json/AuthorisationCaseField/ExpressPilot-nonprod.json
+++ b/definitions/contested/json/AuthorisationCaseField/ExpressPilot-nonprod.json
@@ -63,10 +63,24 @@
     "CRUD": "CRUD"
   },
   {
+    "LiveFrom": "26/03/2025",
+    "CaseTypeID": "FinancialRemedyContested",
+    "CaseFieldID": "suitableForExpressCaseAmendmentLabel",
+    "UserRole": "caseworker-divorce-financialremedy-courtadmin",
+    "CRUD": "CRUD"
+  },
+  {
     "LiveFrom": "13/03/2025",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseFieldID": "unsuitableForExpressCaseAmendmentLabel",
     "UserRole": "caseworker-divorce-financialremedy-solicitor",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "26/03/2025",
+    "CaseTypeID": "FinancialRemedyContested",
+    "CaseFieldID": "unsuitableForExpressCaseAmendmentLabel",
+    "UserRole": "caseworker-divorce-financialremedy-courtadmin",
     "CRUD": "CRUD"
   },
   {

--- a/definitions/contested/json/CaseEventToFields/CaseEventToFields-newPaperCase.json
+++ b/definitions/contested/json/CaseEventToFields/CaseEventToFields-newPaperCase.json
@@ -4428,8 +4428,8 @@
     "CaseFieldID": "promptForAnyDocumentLabel",
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "READONLY",
-    "PageID": 26,
-    "PageDisplayOrder": 26,
+    "PageID": 25,
+    "PageDisplayOrder": 25,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y"
   },
@@ -4440,8 +4440,8 @@
     "CaseFieldID": "promptForAnyDocument",
     "PageFieldDisplayOrder": 2,
     "DisplayContext": "MANDATORY",
-    "PageID": 26,
-    "PageDisplayOrder": 26,
+    "PageID": 25,
+    "PageDisplayOrder": 25,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y"
   },
@@ -4452,8 +4452,8 @@
     "CaseFieldID": "uploadOtherDocumentLabel",
     "PageFieldDisplayOrder": 3,
     "DisplayContext": "READONLY",
-    "PageID": 26,
-    "PageDisplayOrder": 26,
+    "PageID": 25,
+    "PageDisplayOrder": 25,
     "PageColumnNumber": 1,
     "FieldShowCondition": "promptForAnyDocument=\"Yes\"",
     "ShowSummaryChangeOption": "Y"
@@ -4465,8 +4465,8 @@
     "CaseFieldID": "uploadAdditionalDocument",
     "PageFieldDisplayOrder": 4,
     "DisplayContext": "MANDATORY",
-    "PageID": 26,
-    "PageDisplayOrder": 26,
+    "PageID": 25,
+    "PageDisplayOrder": 25,
     "PageColumnNumber": 1,
     "FieldShowCondition": "promptForAnyDocument=\"Yes\"",
     "ShowSummaryChangeOption": "Y"
@@ -4478,8 +4478,8 @@
     "CaseFieldID": "urgentCaseLabel",
     "PageFieldDisplayOrder": 5,
     "DisplayContext": "READONLY",
-    "PageID": 26,
-    "PageDisplayOrder": 26,
+    "PageID": 25,
+    "PageDisplayOrder": 25,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y"
   },
@@ -4490,8 +4490,8 @@
     "CaseFieldID": "promptForUrgentCaseQuestion",
     "PageFieldDisplayOrder": 6,
     "DisplayContext": "MANDATORY",
-    "PageID": 26,
-    "PageDisplayOrder": 26,
+    "PageID": 25,
+    "PageDisplayOrder": 25,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y"
   },
@@ -4502,8 +4502,8 @@
     "CaseFieldID": "urgentCaseQuestionDetailsTextArea",
     "PageFieldDisplayOrder": 7,
     "DisplayContext": "MANDATORY",
-    "PageID": 26,
-    "PageDisplayOrder": 26,
+    "PageID": 25,
+    "PageDisplayOrder": 25,
     "PageColumnNumber": 1,
     "FieldShowCondition": "promptForUrgentCaseQuestion=\"Yes\"",
     "ShowSummaryChangeOption": "Y"
@@ -4515,8 +4515,8 @@
     "CaseFieldID": "beforeSavePreConfirmation",
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "READONLY",
-    "PageID": 27,
-    "PageDisplayOrder": 27,
+    "PageID": 26,
+    "PageDisplayOrder": 26,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N"
   }


### PR DESCRIPTION
### Jira link

**Express Pilot**
https://tools.hmcts.net/jira/browse/DFR-3644
https://tools.hmcts.net/jira/browse/DFR-3645

**Variation Order bug**
https://tools.hmcts.net/jira/browse/DFR-3689

### Change description

**Express Pilot**
Auth fix so that the Caseworker running the amend paper case event can see Express Pilot labels.  There were no issues running locally or in Preview.  But the issue was recreatable in AAT.

**Variation Order bug**
During earlier testing of the same amend paper case event, this bug was spotted when variation order dependent labels were alone on a page with no page show condition.  This meant that nothing appeared on this page when the variation order was missing.

Copied how Create paper case does it, and moved  fields (by one position) to the related page. Means no empty page shows, the variation order fields just show or not.

Isn't obvious in the PR, but look above the changes to CaseEventToFields-newPaperCase.json and you'll see the variation order fields.  I've shunted everything else up to meet them.

### Testing done

Tested in Preview.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
