### PR TITLE
DFR-3670: Add access to field latestDraftHearingOrder for system update role

### DIFF
--- a/definitions/contested/json/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/definitions/contested/json/AuthorisationCaseField/AuthorisationCaseField.json
@@ -6461,6 +6461,13 @@
     "CRUD": "R"
   },
   {
+    "LiveFrom": "12/05/2025",
+    "CaseTypeID": "FinancialRemedyContested",
+    "CaseFieldID": "latestDraftHearingOrder",
+    "UserRole": "caseworker-divorce-systemupdate",
+    "CRUD": "CRUD"
+  },
+  {
     "LiveFrom": "09/11/2021",
     "CaseTypeID": "FinancialRemedyContested",
     "CaseFieldID": "tabSpecialAssistanceRequired",
@@ -19045,7 +19052,7 @@
     "CaseFieldID": "judgeAgreesCaseIsExpress",
     "UserRole": "caseworker-divorce-financialremedy-judiciary",
     "CRUD": "CRU"
-  }, 
+  },
   {
     "LiveFrom": "16/03/2020",
     "CaseTypeID": "FinancialRemedyContested",


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3670

### Change description

Add access to field latestDraftHearingOrder for role caseworker-divoce-systemupdate
The lack of access to this field is causing errors during cron job execution if the field is present on a case being updated