### PR TITLE
DFR-3793: Remove judicial access to old draft order events

### DIFF
--- a/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/contested/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -914,7 +914,7 @@
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_draftOrderNotApproved",
     "UserRole": "caseworker-divorce-financialremedy-judiciary",
-    "CRUD": "CR"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -928,7 +928,7 @@
     "CaseTypeID": "FinancialRemedyContested",
     "CaseEventID": "FR_draftOrderApproved",
     "UserRole": "caseworker-divorce-financialremedy-judiciary",
-    "CRUD": "CR"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2017",


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3793

### Change description

Remove judicial access to old draft order events.
Draft Order Approved and Draft Order Not Approved events are no longer to be used by the judiciary. They have been replaced by the new Approve orders event.