### PR TITLE
quick fix for nightly assert tab failures in case flag tests

### DIFF
--- a/playwright-e2e/pages/CaseDetailsPage.ts
+++ b/playwright-e2e/pages/CaseDetailsPage.ts
@@ -115,6 +115,21 @@ export class CaseDetailsPage {
         return this.page.getByRole('tab', { name: tabName, exact: true });
     }
 
+    /**
+     * Returns the `Locator` for the nth visible element matching the given text content.
+     *
+     * @param content - The exact text to match in the DOM.
+     * @param position - The zero-based index of the visible element to return (default is 0).
+     * @returns A Playwright `Locator` for the requested visible element.
+     * @throws Error if no visible element is found at the specified position.
+     *
+     * Logic:
+     * 1. Finds all elements matching the exact text.
+     * 2. If only one match and position is 0, returns it directly.
+     * 3. Otherwise, iterates through all matches, counting only those that are visible.
+     * 4. Returns the element at the requested visible position.
+     * 5. Throws an error if the requested visible position does not exist.
+     */
     private async getVisibleTabContent(content: string, position: number = 0): Promise<Locator> {
         const locator = this.page.getByText(content, { exact: true });
         const count = await locator.count();
@@ -123,10 +138,14 @@ export class CaseDetailsPage {
             return locator;
         }
 
+        let visibleIndex = 0;
         for (let i = 0; i < count; i++) {
             const element = locator.nth(i);
-            if (await element.isVisible() && i === position) {
-                return element;
+            if (await element.isVisible()) {
+                if (visibleIndex === position) {
+                    return element;
+                }
+                visibleIndex++;
             }
         }
         throw new Error(`No visible element found for content: ${content} at position: ${position}`);


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

Quick fix for nightly failulres in case flag cases.

changed the logic to iterate only for visible elements.
case flag page have multiple DOM elements with hidden state for same String/text we try to find.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
