### PR TITLE
Fix pageId for FR_newPaperCase upload other document field

### DIFF
--- a/definitions/contested/json/CaseEventToFields/CaseEventToFields-newPaperCase.json
+++ b/definitions/contested/json/CaseEventToFields/CaseEventToFields-newPaperCase.json
@@ -2217,8 +2217,8 @@
     "CaseFieldID": "uploadAdditionalDocument",
     "PageFieldDisplayOrder": 6,
     "DisplayContext": "MANDATORY",
-    "PageID": 22,
-    "PageDisplayOrder": 22,
+    "PageID": 23,
+    "PageDisplayOrder": 23,
     "PageColumnNumber": 1,
     "FieldShowCondition": "promptForAnyDocument=\"Yes\"",
     "ShowSummaryChangeOption": "Y"

--- a/playwright-e2e/resources/check_your_answer_content/create_case/createCaseTable.ts
+++ b/playwright-e2e/resources/check_your_answer_content/create_case/createCaseTable.ts
@@ -125,7 +125,7 @@ export const miamDetails: TableRowItem[] = [
 export const variationOrderDetails: TableRowItem[] = [
     'Upload original order to be varied',
     { cellItem: 'Original order to be varied', value: ' Variation order.pdf' },
-    { cellItem: 'Do you want to upload any other documents ?', value: 'No', rowType: 'label-value-adjacent' },
+    { cellItem: 'Do you want to upload any other documents ?', value: 'Yes', rowType: 'label-value-adjacent' },
 ]
 
 export const urgentCase: TableRowItem[] = [
@@ -218,7 +218,7 @@ export const  contestedCreateExpressPaperMatrimonyCaseDetailsTable: Table = {
         { cellItem: 'Of the above value, what is the net value of the family home?', value: '125,000', rowType: 'label-value-adjacent' },
         'Please tick any potential allegations/issues which may arise',
         { cellItem: 'Select all that apply', value: 'Not applicable'},
-        { cellItem: 'Do you want to upload any other documents ?', value: 'No', rowType: 'label-value-adjacent' },
+        { cellItem: 'Do you want to upload any other documents ?', value: 'Yes', rowType: 'label-value-adjacent' },
         ...getCourtDetails("BIRMINGHAM CIVIL AND FAMILY JUSTICE CENTRE"),
         ...miamDetails,
         'You should have a document signed by the mediator confirming this (which you should bring to your first hearing)',

--- a/playwright-e2e/test/contested/FR_CreateCases/create_express_papercase.spec.ts
+++ b/playwright-e2e/test/contested/FR_CreateCases/create_express_papercase.spec.ts
@@ -10,7 +10,7 @@ import {ContestedEvents} from "../../../config/case-data.ts";
 
 // Create a test case for the Contested Paper Case
 test(
-  'Create Case - Contested Paper Case',
+  'Create Case - Contested Paper Case - Express Pilot',
   { tag: ['@additionalTest'] },
   async (
     {
@@ -151,8 +151,9 @@ test(
     await miamDetailsPage.uploadMiamDocPaperCase();
     await miamDetailsPage.navigateContinue(expectedURL,23);
 
-    // Upload variation Order Document
-    await uploadOrderDocumentsPage.selectUploadAdditionalDocs(false);
+    // Upload additional document
+    await uploadOrderDocumentsPage.selectUploadAdditionalDocs(true);
+    await uploadOrderDocumentsPage.uploadOtherDocuments("test1.pdf", "Other");
     await uploadOrderDocumentsPage.selectUrgentCaseQuestionRadio(false);
     await uploadOrderDocumentsPage.navigateContinue(expectedURL + '/submit');
 

--- a/playwright-e2e/test/contested/FR_CreateCases/create_papercase.spec.ts
+++ b/playwright-e2e/test/contested/FR_CreateCases/create_papercase.spec.ts
@@ -153,7 +153,8 @@ test(
 
     // Upload variation Order Document
     await uploadOrderDocumentsPage.uploadVariationOrderDoc();
-    await uploadOrderDocumentsPage.selectUploadAdditionalDocs(false);
+    await uploadOrderDocumentsPage.selectUploadAdditionalDocs(true);
+    await uploadOrderDocumentsPage.uploadOtherDocuments("test1.pdf", "Other");
     await uploadOrderDocumentsPage.selectUrgentCaseQuestionRadio(false);
     await uploadOrderDocumentsPage.navigateContinue(expectedURL + '/submit');
 
@@ -317,7 +318,8 @@ test(
         await miamDetailsPage.navigateContinue(expectedURL, 23);
 
         // Upload variation Order Document
-        await uploadOrderDocumentsPage.selectUploadAdditionalDocs(false);
+        await uploadOrderDocumentsPage.selectUploadAdditionalDocs(true);
+        await uploadOrderDocumentsPage.uploadOtherDocuments("test1.pdf", "Other");
         await uploadOrderDocumentsPage.selectUrgentCaseQuestionRadio(false);
         await uploadOrderDocumentsPage.uploadVariationOrderDoc();
         await uploadOrderDocumentsPage.navigateContinue();


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3934

### Change description

The Upload other documents field appears on the wrong page for the New Paper Case event.
Fix pageId for FR_newPaperCase upload additional document field

**Added Playwright changes to test upload function of the Additional Doc upload field