### PR TITLE
Dfr 3953 refactor parties on case logic to use it's own object on the back end

### DIFF
--- a/definitions/contested/json/ComplexTypes/ManageHearings-nonprod.json
+++ b/definitions/contested/json/ComplexTypes/ManageHearings-nonprod.json
@@ -105,6 +105,24 @@
     "Searchable": "N"
   },
   {
+    "LiveFrom": "22/07/2025",
+    "ID": "FR_partyOnCase",
+    "ListElementCode": "role",
+    "FieldType": "Text",
+    "ElementLabel": "Role",
+    "SecurityClassification": "Public",
+    "Searchable": "N"
+  },
+  {
+    "LiveFrom": "22/07/2025",
+    "ID": "FR_partyOnCase",
+    "ListElementCode": "label",
+    "FieldType": "Text",
+    "ElementLabel": "Label",
+    "SecurityClassification": "Public",
+    "Searchable": "N"
+  },
+  {
     "LiveFrom": "28/04/2025",
     "ID": "FR_hearing",
     "ListElementCode": "hearingType",
@@ -197,24 +215,6 @@
     "FieldType": "YesOrNo",
     "ElementLabel": "Do you want to send a notice of hearing?",
     "HintText": "Hint text yet to be confirmed",
-    "SecurityClassification": "Public",
-    "Searchable": "N"
-  },
-  {
-    "LiveFrom": "22/07/2025",
-    "ID": "FR_partyOnCase",
-    "ListElementCode": "role",
-    "FieldType": "Text",
-    "ElementLabel": "Role",
-    "SecurityClassification": "Public",
-    "Searchable": "N"
-  },
-  {
-    "LiveFrom": "22/07/2025",
-    "ID": "FR_partyOnCase",
-    "ListElementCode": "label",
-    "FieldType": "Text",
-    "ElementLabel": "Label",
     "SecurityClassification": "Public",
     "Searchable": "N"
   },

--- a/definitions/contested/json/ComplexTypes/ManageHearings-nonprod.json
+++ b/definitions/contested/json/ComplexTypes/ManageHearings-nonprod.json
@@ -201,10 +201,29 @@
     "Searchable": "N"
   },
   {
+    "LiveFrom": "22/07/2025",
+    "ID": "FR_partyOnCase",
+    "ListElementCode": "role",
+    "FieldType": "Text",
+    "ElementLabel": "Role",
+    "SecurityClassification": "Public",
+    "Searchable": "N"
+  },
+  {
+    "LiveFrom": "22/07/2025",
+    "ID": "FR_partyOnCase",
+    "ListElementCode": "label",
+    "FieldType": "Text",
+    "ElementLabel": "Label",
+    "SecurityClassification": "Public",
+    "Searchable": "N"
+  },
+  {
     "LiveFrom": "28/04/2025",
     "ID": "FR_hearing",
-    "ListElementCode": "partiesOnCaseMultiSelectList",
-    "FieldType": "DynamicMultiSelectList",
+    "ListElementCode": "partiesOnCase",
+    "FieldType": "Collection",
+    "FieldTypeParameter": "FR_partyOnCase",
     "ElementLabel": "Who should see this order?",
     "SecurityClassification": "Public",
     "Searchable": "N"


### PR DESCRIPTION
### Jira link
[DFR-3953](https://tools.hmcts.net/jira/browse/DFR-3953)

### Change description
- Hearing object will not store the parties on the case using a dynamic multi select list.
- The parties on the case will now be stored using it's own object: FR_partiesOnCase with two properties, role and label.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
