### PR TITLE
DFR-4934: Amended to use new IDAM login

### DIFF
--- a/playwright-e2e/pages/SigninPage.ts
+++ b/playwright-e2e/pages/SigninPage.ts
@@ -1,15 +1,15 @@
 import { type Page, type Locator, expect } from '@playwright/test';
+import { BaseJourneyPage } from './BaseJourneyPage';
 import config from '../config/config.ts';
 
-export class SigninPage {
+export class SigninPage extends BaseJourneyPage{
   
-  private readonly page: Page;
   private readonly emailInputLocator: Locator;
   private readonly passwordInputLocator: Locator;
   private readonly signinButtonLocator: Locator;
 
   public constructor(page: Page) {
-    this.page = page;
+    super(page);
     this.emailInputLocator = page.getByLabel('Email address');
     this.passwordInputLocator = page.getByRole('textbox', { name: 'Password' });
     this.signinButtonLocator = page.getByRole('button', { name: 'Sign in' });
@@ -18,11 +18,10 @@ export class SigninPage {
   private async login(email: string, password: string) {
     await expect(this.emailInputLocator).toBeVisible();
     await this.emailInputLocator.fill(email);
+    await this.navigateContinue();
     await expect(this.passwordInputLocator).toBeVisible();
     await this.passwordInputLocator.fill(password);
-    await expect(this.signinButtonLocator).toBeVisible();
-    await expect(this.signinButtonLocator).toBeEnabled();
-    await this.signinButtonLocator.click();
+    await this.navigateContinue();
   }
 
   /**

--- a/playwright-e2e/pages/SigninPage.ts
+++ b/playwright-e2e/pages/SigninPage.ts
@@ -6,13 +6,11 @@ export class SigninPage extends BaseJourneyPage{
   
   private readonly emailInputLocator: Locator;
   private readonly passwordInputLocator: Locator;
-  private readonly signinButtonLocator: Locator;
 
   public constructor(page: Page) {
     super(page);
     this.emailInputLocator = page.getByLabel('Email address');
     this.passwordInputLocator = page.getByRole('textbox', { name: 'Password' });
-    this.signinButtonLocator = page.getByRole('button', { name: 'Sign in' });
   }
 
   private async login(email: string, password: string) {


### PR DESCRIPTION
### Jira link

[DFR-4934](https://tools.hmcts.net/jira/browse/DFR-4934)

### Change description

New IDAM page actually simpler.  I changed the SignInPage to inherit from the BaseJourneyPage then just used navigateContinue.  IDAM have kept the same page labels so that the other locators still work.

### Testing done

Ran on a selection of tests, all worked.  Could not see any outliers that do not use SignInPage, but will run the nightlies after merge to check.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
